### PR TITLE
Fix missing extra-source-files

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -16,8 +16,7 @@ benchmarks:
 category: Other
 description: Ramus is a direct port of purescript-signal into Haskell, offering the Elm signal system for Haskell.
 extra-source-files:
-- CHANGELOG.md
-- LICENSE.md
+- LICENSE
 - package.yaml
 - README.md
 - stack.yaml


### PR DESCRIPTION
Neither `CHANGELOG.md` nor `LICENSE.md` exist in the repo.